### PR TITLE
cache: try the current directory if the target is not found

### DIFF
--- a/caches/cache.go
+++ b/caches/cache.go
@@ -58,7 +58,14 @@ func ComputeFingerPrint(clangTidyPath string, invocation *clang.TidyInvocation, 
 	// extract the compilation target command flags from the database
 	targetFlags, err := clang.ExtractCompilationTarget(invocation.DatabaseRoot, invocation.TargetPath)
 	if err != nil {
-		return nil, err
+		cwd, wderr := os.Getwd()
+		if wderr != nil {
+			return nil, err
+		}
+		targetFlags, err = clang.ExtractCompilationTarget(cwd, invocation.TargetPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// parse the main clang flags


### PR DESCRIPTION
CMake generates its `compile_commands.json` in the build tree which may have no relation to the source file's path. Search the current working directory for `compile_commands.json` as well when this happens.

https://github.com/ejfitzgerald/clang-tidy-cache/pull/24