### PR TITLE
fileSystem: remember the original search path for the error message

### DIFF
--- a/utils/fileSystem.go
+++ b/utils/fileSystem.go
@@ -11,6 +11,10 @@ import (
 // Returns the full path to the file when found, starting the search in
 // searchDir and moving up to the parent directories.
 func FindInParents(searchDir string, filename string) (string, error) {
+	return findInParentsOrig(searchDir, searchDir, filename)
+}
+
+func findInParentsOrig(origSearchDir string, searchDir string, filename string) (string, error) {
 	currentPath := filepath.Join(searchDir, filename)
 	if _, err := os.Stat(currentPath); err == nil {
 		return currentPath, nil
@@ -18,7 +22,7 @@ func FindInParents(searchDir string, filename string) (string, error) {
 	// File does not exists, try any parent directories recursively
 	parentDir := filepath.Dir(searchDir)
 	if parentDir == searchDir {
-		return "", fmt.Errorf("Failed to find %v in %v or any of the parent directories", filename, searchDir)
+		return "", fmt.Errorf("Failed to find %v in %v or any of the parent directories", filename, origSearchDir)
 	}
-	return FindInParents(parentDir, filename)
+	return findInParentsOrig(origSearchDir, parentDir, filename)
 }


### PR DESCRIPTION
Without this, the error message is that it could not be found in the `/` path or any of its parents which is just misleading.

https://github.com/ejfitzgerald/clang-tidy-cache/pull/22