### PR TITLE
clangArgumentParser: use `shlex` to parse commands

### DIFF
--- a/clang/clangArgumentParser.go
+++ b/clang/clangArgumentParser.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/google/shlex"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,7 +20,10 @@ type CompilerCommand struct {
 }
 
 func ParseClangCommandString(commands string) (*CompilerCommand, error) {
-	words := strings.Fields(commands)
+	words, err := shlex.Split(commands)
+	if err != nil {
+		return nil, err
+	}
 
 	var cmd CompilerCommand
 	cmd.Compiler = words[0]

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,6 @@ require (
 	google.golang.org/grpc v1.40.1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
+require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+)

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=


### PR DESCRIPTION
Commands in the JSON database may be escaped for the shell. Perform unescaping so that escaped characters don't get mangled.

---
Resubmission of https://github.com/ejfitzgerald/clang-tidy-cache/pull/26.